### PR TITLE
Fixing ci pipeline issues and Documentation editing

### DIFF
--- a/.github/workflows/hivebox-ci.yml
+++ b/.github/workflows/hivebox-ci.yml
@@ -2,8 +2,6 @@ name: hivebox-ci
 
 on:
   push:
-    branches-ignore:
-      - main
   pull_request: 
     branches:  
       - main
@@ -16,9 +14,12 @@ concurrency:
 jobs:
   hivebox-build-and-test:
     runs-on: ubuntu-24.04
+    outputs:
+      built: ${{ steps.build.outputs.built }}
+      image_version: ${{ steps.build.outputs.image_version }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@49c0eed3a423f00c872b5c3c9f1bbca9e8aae799 #v4.13.1
         with:
           fetch-depth: 0
 
@@ -40,6 +41,19 @@ jobs:
       - name: Unit Testing
         if: steps.build.outputs.built == 'true'
         run: docker run --rm --entrypoint uv hivebox:latest run pytest tests/
+      # 4- push to registry
+      - name: Log in to Docker Hub
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 #v3.7.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Push image to Docker Hub
+        run: |
+          docker tag hivebox:latest ${{ secrets.DOCKERHUB_USERNAME }}/hivebox:${{ steps.build.outputs.image_version }}
+          docker tag hivebox:latest ${{ secrets.DOCKERHUB_USERNAME }}/hivebox:latest
+          docker push ${{ secrets.DOCKERHUB_USERNAME }}/hivebox:${{ steps.build.outputs.image_version }}
+          docker push ${{ secrets.DOCKERHUB_USERNAME }}/hivebox:latest
 
   # Setting up OSSF scoreboard
   scorecard:
@@ -72,20 +86,3 @@ jobs:
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: results.sarif
-  # pushing our app image to dockerhub
-  push-to-registry:
-    needs: scorecard
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Push image to Docker Hub
-        run: |
-          docker tag hivebox:latest ${{ secrets.DOCKERHUB_USERNAME }}/hivebox:${{ github.ref_name }}
-          docker tag hivebox:latest ${{ secrets.DOCKERHUB_USERNAME }}/hivebox:latest
-          docker push ${{ secrets.DOCKERHUB_USERNAME }}/hivebox:${{ github.ref_name }}
-          docker push ${{ secrets.DOCKERHUB_USERNAME }}/hivebox:latest

--- a/.github/workflows/hivebox-ci.yml
+++ b/.github/workflows/hivebox-ci.yml
@@ -3,7 +3,7 @@ name: hivebox-ci
 on:
   push:
   pull_request: 
-    branches:  
+    branches:
       - main
   workflow_dispatch:
 
@@ -19,7 +19,7 @@ jobs:
       image_version: ${{ steps.build.outputs.image_version }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@49c0eed3a423f00c872b5c3c9f1bbca9e8aae799 #v4.13.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           fetch-depth: 0
 
@@ -43,7 +43,7 @@ jobs:
         run: docker run --rm --entrypoint uv hivebox:latest run pytest tests/
       # 4- push to registry
       - name: Log in to Docker Hub
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 #v3.7.0
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 #v4.17.21
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -83,6 +83,6 @@ jobs:
           retention-days: 5
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@29181f28d55fcc032f21a33f8ad0847965867c55 #v3.1.5
         with:
           sarif_file: results.sarif

--- a/.github/workflows/hivebox-ci.yml
+++ b/.github/workflows/hivebox-ci.yml
@@ -2,8 +2,11 @@ name: hivebox-ci
 
 on:
   push:
-  pull_request: 
     branches:
+      - main
+      - feature/*
+  pull_request: 
+    branches: 
       - main
   workflow_dispatch:
 
@@ -13,7 +16,7 @@ concurrency:
 
 jobs:
   hivebox-build-and-test:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     outputs:
       built: ${{ steps.build.outputs.built }}
       image_version: ${{ steps.build.outputs.image_version }}
@@ -56,15 +59,16 @@ jobs:
           docker push ${{ secrets.DOCKERHUB_USERNAME }}/hivebox:latest
 
   # Setting up OSSF scoreboard
-  scorecard:
+  ossf_scorecard:
     needs: hivebox-build-and-test
+    if: github.ref_name == 'main'
     runs-on: ubuntu-latest
     permissions:
       security-events: write
       id-token: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           persist-credentials: false
 

--- a/README.md
+++ b/README.md
@@ -1,46 +1,129 @@
 [![Dynamic DevOps Roadmap](https://img.shields.io/badge/Dynamic_DevOps_Roadmap-559e11?style=for-the-badge&logo=Vercel&logoColor=white)](https://devopsroadmap.io/getting-started/)
+
 [![Community](https://img.shields.io/badge/Join_Community-%23FF6719?style=for-the-badge&logo=substack&logoColor=white)](https://newsletter.devopsroadmap.io/subscribe)
+
 [![Telegram Group](https://img.shields.io/badge/Telegram_Group-%232ca5e0?style=for-the-badge&logo=telegram&logoColor=white)](https://t.me/DevOpsHive/985)
+
 [![Fork on GitHub](https://img.shields.io/badge/Fork_On_GitHub-%2336465D?style=for-the-badge&logo=github&logoColor=white)](https://github.com/DevOpsHiveHQ/devops-hands-on-project-hivebox/fork)
+
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/MennaSalah03/devops-hands-on-project-hivebox/badge)](https://scorecard.dev/viewer/?uri=github.com/MennaSalah03/devops-hands-on-project-hivebox)
+
+  
+  
 
 # HiveBox - DevOps End-to-End Hands-On Project
 
+  
+
 <p align="center">
-  <a href="https://devopsroadmap.io/projects/hivebox" style="display: block; padding: .5em 0; text-align: center;">
-    <img alt="HiveBox - DevOps End-to-End Hands-On Project" border="0" width="90%" src="https://devopsroadmap.io/img/projects/hivebox-devops-end-to-end-project.png" />
-  </a>
+
+<a href="https://devopsroadmap.io/projects/hivebox" style="display: block; padding: .5em 0; text-align: center;">
+
+<img alt="HiveBox - DevOps End-to-End Hands-On Project" border="0" width="90%" src="https://devopsroadmap.io/img/projects/hivebox-devops-end-to-end-project.png" />
+
+</a>
+
 </p>
 
-The project aims to cover the whole Software Development Life Cycle (SDLC). That means each phase will cover all aspects of DevOps, such as planning, coding, containers, testing, continuous integration, continuous delivery, infrastructure, etc.
+
+PS: stay tuned for my attempt at making an alternative logo for the project :D
+  
+
+This multi-phase project is mainly for learning purposes and aims to cover the whole Software Development Life Cycle (SDLC). That entails that the phases would cover all aspects of DevOps, such as planning, coding, containers, orchestration, various types of testing, continuous integration, continuous delivery, infrastructure, etc.
+
+  
+I you are attempting to do this project or a similar fashioned one, I have compiled most of the resources that helped me throughout my journey, you can find it in the `docs/RESOURCES.md` file or [here](https://github.com/MennaSalah03/devops-hands-on-project-hivebox/blob/main/docs/RESOURCES.md))
 
 ---
 ## Current Progress
-Phase | Progress 
---- | --- 
-Phase 1 | Done
-Phase 2 | Done
-Phase 3 | In progress...
-Phase 4 | Not Started
-Phase 5 | Not Started
-Phase 6 | Not Started
-Phase 7 | Not Started
+
+| Phase   | Progress   |
+| ------- | ---------- |
+| Phase 1 | ✅ Done     |
+| Phase 2 | ✅ Done     |
+| Phase 3 | ✅ Done     |
+| Phase 4 | ⏳Next      |
+| Phase 5 | ♾️ Pending |
+| Phase 6 | ♾️ Pending |
+The final architecture of the project:
 
 
-## Phases 1 and 2: Introduction and DevOps Core
+![hivebox](https://devopsroadmap.io/assets/images/hivebox-architecture-a7fe504c22027e87b6f7b188cd57d2d8.png)
 
-For these phases, the project is just started. Phase 1 is the creation/forking of the repository and phase 2 is a small image creation for the app that at this stage only stores and prints the version of the app and also assigns it to the image tag.
+for running the project at the current stage, you'll need to navigate to the working directory and run the following:
+```
+./build.sh
+```
 
-The build is done by running the `build.sh` script in the repository's root directory, which:
-1. runs the script responsible for getting the latest version
-2. Building the app with the `Dockerfile` thereby generating the image with the current version.
+## [Phase 1]((https://devopsroadmap.io/foundations/module-01/) & [ Phase 2](https://devopsroadmap.io/foundations/module-02/):  Project Foundation
+
+In phases 1 and 2, we start to to set up our working tree and experiment with project management tools and git best practices we will be using in the next phases.
+
+### Phase Deliverables:
+- Forking the original repository.
+- Understanding how to operate a repo as if in a team setting and good practices like working on separate branches and using PRs to merge to main.
+- Deciding on an Agile methodology (Kanban)
+- Learning about scope creep and how to avoid it.
+- Creating a basic `Dockerfile` for the project with some best practices applied (optimal base image, run with non-root user).
+- Using `uv` for dependency management instead of `requirements.txt`.
+- Learning and using Semantic Versioning for repository tags and docker images for ensuring absolute traceability between the code base and docker images.
+## Personal Technical Growth
+- Automating the app build with having a script to run instead of manual error-prone CLI commands.
+- Understanding Semantic versioning and integrating it in the build process.
+
+### Technical Challenges & Engineering Decisions
+- Kanban: GitHub has a built-in Kanban board feature on GUI which is highly accessible to use especially for a solo-developed project and it hasn't been complicated so far. It was also the roadmap's recommended methodology for the project.
+## [Phase 3: Start - Laying the Base](https://devopsroadmap.io/foundations/module-03/)
+start date: 28/2/2026 
+finish date: 19/4/2026
+time taken: 30+ hrs.
+### Phase Deliverables:
+- Creation of the app's API (I used [FastAPI](https://fastapi.tiangolo.com/)) with 2 endpoints required.
+	- `/version` to display the supposed current app's version.
+	- `/temperature` to display the average temperature of **all** sensor-boxes across the globe from the [OpensenseAPI](https://docs.opensensemap.org/#api-_).
+	- The root endpoint have been added with a welcome message to not cause unnecessary error if accessed.
+- Unit testing the code using `pytest`.
+* Applying more of Docker's Best practices. 
+	* Use Dockerfile linter (`hadolint`).
+	* using `HEALTHCHECK`.
+	* Use `ENTRYPOINT` with `CMD`.
+	* Avoid any unnecessary files (using `.dockerignore`)
+
+* Creating a continuous integration pipeline (I chose GitHub Actions for implementation) to include
+	* Linting the python code (Pylint) and Dockerfile (Hadolint).
+	* Building the app's image with Docker
+	* Unit testing the app.
+	* Setting up an OSSF scoreboard.
 
 
-## Phase 3
+## Personal Technical Growth
+- Exploration of APIs using the `OpensenseAPI` and it's docs.
+- Learning FastAPI to create `/temperature` and `/version` endpoints and more about APIs in general.
+- Doing unit tests with  `pytest` and `unittest`'s `MockMagic` (helped with creating mock data for testing endpoints).
+- Getting better at using git above the level of just basic commits and pushes.
+	- Using the `--amend` flag for editing my commits and messages freely
+	- Understanding and using tags efficiently in SemVer.
+	- Successfully creating my first PR and merge to main.
+- Using GitHub Actions for the first time in an automated pipeline of a real project.
+- Creating and using repository-wide secrets for docker hub credentials.
+- Got a better grasp on management of tasks and issues using the Kanban board.
 
-This Phase marks the beginning of using the Kanban Board to tackle the upcoming tasks. So far, their usage included adding the "backlog" tasks provided in the phase's instruction without much breaking tasks up just yet. This would need improvement in later phases.
+### Technical Challenges & Engineering Decisions
+- GitHub Actions: Simpler to use, especially for doing pipelines for the first time, already built in GitHub for immediate use, and uses `yaml` files for configuration.
+- FastAPI: Modern, Async, type hinting and it also has a moderate learning curve between Flask and Django. 
+- Pytest: code efficiency as  it has fixtures which helps reducing the repetition in the code, easy to write and understand and integrates seamlessly with modern automation tools
 
-This phase's highlight is the continuous integration with a tool like Github Actions (the one I will be using) or Jenkins. However, it also had another part, which is the app's API using a framework (Flask, Fastapi or Django). I have opted to choose fastapi because it seemed competent, but not too simple as I have heard when researching Flask.
+### What I'd change for next phases
+Practices and habits:
+- Using the Kanban board more frequently and efficiently even for small issues.
+- Doing Pull requests semi-daily.
+- Documenting daily achievements and fails (keeping a dev diary).
+- Dedicating more time for theory and focused research.
+- Having more strict time deadlines for features.
+Technical additions:
+- Adding image promotion (to latest) conditions.
+- Fixing vulnerabilities suggested by OSSF scoreboard and giving some priority to learning and applying security practices.
+- Learning to attach fixed issues to commits.
+---
 
-It took about ~8 hours to reach the state of having the `/version` and the `/temperature` endpoints to be created successfully.
-
-TBC...
+*This Project is Part of my YearOfDevOps journey which I post regularly about on [Twitter/X](https://x.com/Menna_Salah03)*

--- a/README.md
+++ b/README.md
@@ -1,38 +1,29 @@
 [![Dynamic DevOps Roadmap](https://img.shields.io/badge/Dynamic_DevOps_Roadmap-559e11?style=for-the-badge&logo=Vercel&logoColor=white)](https://devopsroadmap.io/getting-started/)
-
 [![Community](https://img.shields.io/badge/Join_Community-%23FF6719?style=for-the-badge&logo=substack&logoColor=white)](https://newsletter.devopsroadmap.io/subscribe)
-
 [![Telegram Group](https://img.shields.io/badge/Telegram_Group-%232ca5e0?style=for-the-badge&logo=telegram&logoColor=white)](https://t.me/DevOpsHive/985)
-
 [![Fork on GitHub](https://img.shields.io/badge/Fork_On_GitHub-%2336465D?style=for-the-badge&logo=github&logoColor=white)](https://github.com/DevOpsHiveHQ/devops-hands-on-project-hivebox/fork)
-
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/MennaSalah03/devops-hands-on-project-hivebox/badge)](https://scorecard.dev/viewer/?uri=github.com/MennaSalah03/devops-hands-on-project-hivebox)
 
   
   
-
 # HiveBox - DevOps End-to-End Hands-On Project
 
-  
-
 <p align="center">
-
 <a href="https://devopsroadmap.io/projects/hivebox" style="display: block; padding: .5em 0; text-align: center;">
-
 <img alt="HiveBox - DevOps End-to-End Hands-On Project" border="0" width="90%" src="https://devopsroadmap.io/img/projects/hivebox-devops-end-to-end-project.png" />
-
 </a>
-
 </p>
 
 
 PS: stay tuned for my attempt at making an alternative logo for the project :D
-  
 
 This multi-phase project is mainly for learning purposes and aims to cover the whole Software Development Life Cycle (SDLC). That entails that the phases would cover all aspects of DevOps, such as planning, coding, containers, orchestration, various types of testing, continuous integration, continuous delivery, infrastructure, etc.
 
-  
-I you are attempting to do this project or a similar fashioned one, I have compiled most of the resources that helped me throughout my journey, you can find it in the `docs/RESOURCES.md` file or [here](https://github.com/MennaSalah03/devops-hands-on-project-hivebox/blob/main/docs/RESOURCES.md))
+If you are attempting to do this project or a similar fashioned one, I have compiled most of the resources that helped me throughout my journey, you can find it in the `docs/RESOURCES.md` file or [here](https://github.com/MennaSalah03/devops-hands-on-project-hivebox/blob/main/docs/RESOURCES.md))
+
+The final architecture of the project:
+
+![hivebox](https://devopsroadmap.io/assets/images/hivebox-architecture-a7fe504c22027e87b6f7b188cd57d2d8.png)
 
 ---
 ## Current Progress
@@ -45,17 +36,61 @@ I you are attempting to do this project or a similar fashioned one, I have compi
 | Phase 4 | ⏳Next      |
 | Phase 5 | ♾️ Pending |
 | Phase 6 | ♾️ Pending |
-The final architecture of the project:
 
+current repository structure:
 
-![hivebox](https://devopsroadmap.io/assets/images/hivebox-architecture-a7fe504c22027e87b6f7b188cd57d2d8.png)
-
-for running the project at the current stage, you'll need to navigate to the working directory and run the following:
 ```
-./build.sh
+.
+├── Dockerfile
+├── README.md
+├── build.sh
+├── docs
+│   └── RESOURCES.md
+├── .github/workflows
+|	├── hivebox-ci.yml
+|	└── scorecard.yml
+├── src
+│   ├── main.py
+│   ├── print_version.py
+│   └── version.txt
+├── tests
+│   ├── __init__.py
+│   ├── conftest.py
+│   ├── test_app.py
+│   └── test_version_printer.py
+├── pyproject.toml
+└── uv.lock
 ```
 
-## [Phase 1]((https://devopsroadmap.io/foundations/module-01/) & [ Phase 2](https://devopsroadmap.io/foundations/module-02/):  Project Foundation
+Current Tech Stack:
+- Backend: Python 3.12, FastAPI
+- Package Manager: uv
+- Testing: Pytest, MockMagic (unittest)
+- CI/CD: GitHub Actions
+- Security: OpenSSF Scorecard, Hadolint
+- Registry: Docker Hub
+
+### How to Use the App
+Pull the image from [DockerHub](https://hub.docker.com/repository/docker/menna011/hivebox/general) and run it
+
+```
+docker run --rm -d -p 8000:8000/tcp hivebox:latest
+```
+*Access the API at http://localhost:8000 or view the docs at http://localhost:8000/docs.*
+
+For developer setup:
+1. Install [uv](https://docs.astral.sh/uv/getting-started/installation/#standalone-installer)
+2. Sync environment: `uv sync`
+3. Run Tests using pytest: `pytest tests/`
+4. Local Build: bash build.sh (This script handles local image creation). Ensure it's executable before running. `chmod +x build.sh`
+
+### App's API Endpoints:
+All the current endpoints are `GET` requests that retreives data from the API.
+- `/`: Welcome message `{"message": "Welcome to HiveBox"}`
+- `/version`: Returns current SemVer `{"version": "1.2.0"}`
+- `/temperature`: Returns global temperature sensors average `"{"average_temperature": 22.5}`
+
+## Phase 1 & Phase 2: Project Foundation
 
 In phases 1 and 2, we start to to set up our working tree and experiment with project management tools and git best practices we will be using in the next phases.
 
@@ -73,7 +108,7 @@ In phases 1 and 2, we start to to set up our working tree and experiment with pr
 
 ### Technical Challenges & Engineering Decisions
 - Kanban: GitHub has a built-in Kanban board feature on GUI which is highly accessible to use especially for a solo-developed project and it hasn't been complicated so far. It was also the roadmap's recommended methodology for the project.
-## [Phase 3: Start - Laying the Base](https://devopsroadmap.io/foundations/module-03/)
+## Phase 3: Start - Laying the Base
 start date: 28/2/2026 
 finish date: 19/4/2026
 time taken: 30+ hrs.
@@ -122,7 +157,7 @@ Practices and habits:
 - Having more strict time deadlines for features.
 Technical additions:
 - Adding image promotion (to latest) conditions.
-- Fixing vulnerabilities suggested by OSSF scoreboard and giving some priority to learning and applying security practices.
+- Fixing vulnerabilities suggested by OSSF scoreboard (score is 3.6/10) and giving higher priority to learning and applying security practices.
 - Learning to attach fixed issues to commits.
 ---
 

--- a/build.sh
+++ b/build.sh
@@ -10,5 +10,7 @@ if [ -z "$VERSION" ]; then
 fi
 echo "$VERSION" > src/version.txt
 
-docker image build -t hivebox:${VERSION:1} -t hivebox:latest .
+IMAGE_VERSION=${VERSION:1}
+docker image build -t hivebox:$IMAGE_VERSION -t hivebox:latest .
 echo "built=true" >> $GITHUB_OUTPUT
+echo "image_version=$IMAGE_VERSION" >> $GITHUB_OUTPUT

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -1,0 +1,32 @@
+
+# 🐝 My Resources for Hivebox 🐝
+
+This file is a compilation of all the resources that were useful to me on my journey through the Hivebox project in relation to the [Dynamic DevOps Roadmap](https://devopsroadmap.io/) by Eng. Ahmed Abozaid. The resources do not include the ones that were suggested in the roadmap, but a personal recommendation from me.
+
+Don’t take any of the resources seriously. You don’t have to finish a resource completely if you got the information you wanted from it for the project. You can just get back to it later when you need it!
+
+I am still on phase 4 so, it’s not complete as of yet
+Created by: Menna Salah: [GitHub](https://github.com/MennaSalah03) | [Twitter (x)](https://x.com/Menna_Salah03) | [LinkedIn](https://www.linkedin.com/in/menna-salah/)
+Started file On: 18/4/2026
+
+---
+# ⭐Phase 1 & Phase 2
+- [Agile Project Management with Kanban](https://youtu.be/CD0y-aU1sXo?si=J80DMnQILMHAnQ-u) (Video) 
+- [Git Branches, Forks and Pull Requests](https://www.youtube.com/watch?v=oa1wXWeH1IQ) (videos)
+
+# ⭐Phase 3
+
+## APIs
+- [APIs for Beginners - FreeCodeCamp](https://www.youtube.com/watch?v=WXsD0ZgxjRw&t=91s) (video) (English)
+- [FastAPI Playlist - Code With D](https://www.youtube.com/playlist?list=PLGbzY-VLUfcpzhB-iyGvju-NMMez_NNP9) (video) (Arabic)
+
+## Project Management & Documentation
+
+- [How to document your code like a pro](https://www.youtube.com/watch?v=L7Ry-Fiij-M) (Video) (English)
+## Continuous Integration
+- [GitHub Actions Beginner to Pro](https://courses.devopsdirective.com/github-actions-beginner-to-pro/lessons/00-introduction/01-main) (videos + text course) (English)
+- [Martin Fowler - Continuous Integration](https://martinfowler.com/articles/continuousIntegration.html) (Article) (recommended for CI concepts) (English)
+
+# ⭐ Phase 4
+
+TBC...

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,0 @@
-
-fastapi
-slowapi
-pydantic_settings
-httpx[h2]
-uvicorn[standard]
-pytest


### PR DESCRIPTION
Summary: This PR include multiple tiny fixes to the ci workflow + considerable additions to the docs
Fixes:
- Using commits' SHAs instead of versions for actions
- Making the scoreboard job only work if triggered on the main branch
- Having the push to registry as a step in teh build-and-test job at the end after tests
- Taking the image version as an input from the build script to be used in the workflow for testing and pushing to registry
Docs:
- Editing Phase 1 and 2 to contain more details about technical challenges and deliverables
- Editing the Introduction including the progress table that phase 3 is done and technical details about the current state of the project and how to use it
- Documenting phase 3 (time taken, deliverables, challenges, future plans and learned lessons)
closes #11